### PR TITLE
Remove export command adding redundant/duplicate binary paths into execution environment

### DIFF
--- a/util/mkclean
+++ b/util/mkclean
@@ -4,8 +4,6 @@
 #  current architecture.
 
 
-export 	PATH=/sbin:/usr/sbin:/bin:/usr/bin:/usr/5bin:/usr/ucb:/etc:/usr/etc:$PATH:/usr/local/bin:/opt/local/bin:/local/bin:/home/local/bin
-
 # Initialize the $iraf and environment.
 if [ -z "$iraf" ]; then
   if [ -e "$HOME/.iraf/setup.sh" ]; then


### PR DESCRIPTION
Small change, but this should help to de-clutter the build when debugging the make process.

@RobSteele49 - can you test this commit in your environment to make sure this doesn't break the build for you?