### PR TITLE
Accept zero date in archives

### DIFF
--- a/unix/boot/mkpkg/scanlib.c
+++ b/unix/boot/mkpkg/scanlib.c
@@ -6,6 +6,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <ctype.h>
+#include <sys/stat.h>
 
 #include <ar.h>
 #ifdef MACOSX
@@ -72,6 +73,7 @@ h_scanlibrary (char *library)
 	long	length, fdate;
 	int	len=0, len_arfmag, nmodules;
 	FILE	*fp;
+	struct stat library_stat;
 
 	/* Get the library file name. */
 	h_getlibname (library, libfname);
@@ -93,6 +95,10 @@ h_scanlibrary (char *library)
 	    fflush (stdout);
 	    return (0);
 	}
+
+	/* Get the file date.
+	 */
+	stat(libfname, &library_stat);
 
 	if (debug) {
 	    printf ("scan unix archive %s:\n", libfname);
@@ -205,6 +211,11 @@ h_scanlibrary (char *library)
 #endif
 	        /* Get module date.  */
 	        sscanf (arf.ar_date, "%ld", &fdate);
+
+		/* Use the library date if the module date is not available */
+		if (fdate == 0) {
+		  fdate = library_stat.st_mtime;
+		}
 
 	        /* Insert entry into symbol table. */
 	        mlb_setdate (modname, fdate);


### PR DESCRIPTION
A zero date is a valid (and not anymore unplausible) entry in an
library archive. Archives with that entries can f.e. created with
newer GNU ar and the `D` option, or when the
`--enable-deterministic-archives` option was set during the build of
ar.

To allow at least some updating, we use the last modified date of the library if the date is set to zero.