### PR TITLE
Fix declaration of cdsmem in rpp

### DIFF
--- a/unix/boot/spp/rpp/ratlibf/delete.f
+++ b/unix/boot/spp/rpp/ratlibf/delete.f
@@ -1,7 +1,7 @@
       subroutine delete (symbol, st)
       integer symbol (100)
       integer st
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer stlu
       integer node, pred

--- a/unix/boot/spp/rpp/ratlibf/dsdbiu.f
+++ b/unix/boot/spp/rpp/ratlibf/dsdbiu.f
@@ -1,7 +1,7 @@
       subroutine dsdbiu (b, form)
       integer b
       integer form
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer l, s, lmax
       integer blanks(6)

--- a/unix/boot/spp/rpp/ratlibf/dsdump.f
+++ b/unix/boot/spp/rpp/ratlibf/dsdump.f
@@ -1,6 +1,6 @@
       subroutine dsdump (form)
       integer form
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer p, t, q
       t = 2

--- a/unix/boot/spp/rpp/ratlibf/dsfree.f
+++ b/unix/boot/spp/rpp/ratlibf/dsfree.f
@@ -1,6 +1,6 @@
       subroutine dsfree (block)
       integer block
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer p0, p, q
       integer n, junk

--- a/unix/boot/spp/rpp/ratlibf/dsget.f
+++ b/unix/boot/spp/rpp/ratlibf/dsget.f
@@ -1,6 +1,6 @@
       integer function dsget (w)
       integer w
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer p, q, l
       integer n, k, junk

--- a/unix/boot/spp/rpp/ratlibf/dsinit.f
+++ b/unix/boot/spp/rpp/ratlibf/dsinit.f
@@ -1,6 +1,6 @@
       subroutine dsinit (w)
       integer w
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer t
       if (.not.(w .lt. 2 * 2 + 2))goto 23000

--- a/unix/boot/spp/rpp/ratlibf/enter.f
+++ b/unix/boot/spp/rpp/ratlibf/enter.f
@@ -2,7 +2,7 @@
       integer symbol (100)
       integer info (100)
       integer st
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer i, nodsiz, j
       integer stlu, length

--- a/unix/boot/spp/rpp/ratlibf/lookup.f
+++ b/unix/boot/spp/rpp/ratlibf/lookup.f
@@ -2,7 +2,7 @@
       integer symbol (100)
       integer info (100)
       integer st
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer i, nodsiz, kluge
       integer stlu

--- a/unix/boot/spp/rpp/ratlibf/mktabl.f
+++ b/unix/boot/spp/rpp/ratlibf/mktabl.f
@@ -1,6 +1,6 @@
       integer function mktabl (nodsiz)
       integer nodsiz
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer st
       integer dsget

--- a/unix/boot/spp/rpp/ratlibf/rmtabl.f
+++ b/unix/boot/spp/rpp/ratlibf/rmtabl.f
@@ -1,6 +1,6 @@
       subroutine rmtabl (st)
       integer st
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer i
       integer walker, bucket, node

--- a/unix/boot/spp/rpp/ratlibf/sctabl.f
+++ b/unix/boot/spp/rpp/ratlibf/sctabl.f
@@ -2,7 +2,7 @@
       integer table, posn
       integer sym (100)
       integer info (100)
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer bucket, walker
       integer dsget

--- a/unix/boot/spp/rpp/ratlibf/stlu.f
+++ b/unix/boot/spp/rpp/ratlibf/stlu.f
@@ -1,7 +1,7 @@
       integer function stlu (symbol, node, pred, st)
       integer symbol (100)
       integer node, pred, st
-      integer mem( 1)
+      integer mem( 60000)
       common/cdsmem/mem
       integer hash, i, j, nodsiz
       nodsiz = mem (st)

--- a/unix/boot/spp/rpp/ratlibr/delete.r
+++ b/unix/boot/spp/rpp/ratlibr/delete.r
@@ -6,7 +6,7 @@ include	defs
    character symbol (ARB)
    pointer st
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer stlu
 

--- a/unix/boot/spp/rpp/ratlibr/dsdbiu.r
+++ b/unix/boot/spp/rpp/ratlibr/dsdbiu.r
@@ -6,7 +6,7 @@ include	defs
    pointer b
    character form
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer l, s, lmax
 

--- a/unix/boot/spp/rpp/ratlibr/dsdump.r
+++ b/unix/boot/spp/rpp/ratlibr/dsdump.r
@@ -5,7 +5,7 @@ include	defs
    subroutine dsdump (form)
    character form
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer p, t, q
 

--- a/unix/boot/spp/rpp/ratlibr/dsfree.r
+++ b/unix/boot/spp/rpp/ratlibr/dsfree.r
@@ -5,7 +5,7 @@ include	defs
    subroutine dsfree (block)
    pointer block
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer p0, p, q
 

--- a/unix/boot/spp/rpp/ratlibr/dsget.r
+++ b/unix/boot/spp/rpp/ratlibr/dsget.r
@@ -5,7 +5,7 @@ include	defs
    pointer function dsget (w)
    integer w
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer p, q, l
 

--- a/unix/boot/spp/rpp/ratlibr/dsinit.r
+++ b/unix/boot/spp/rpp/ratlibr/dsinit.r
@@ -5,7 +5,7 @@ include	defs
    subroutine dsinit (w)
    integer w
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer t
 

--- a/unix/boot/spp/rpp/ratlibr/enter.r
+++ b/unix/boot/spp/rpp/ratlibr/enter.r
@@ -7,7 +7,7 @@ include	defs
    integer info (ARB)
    pointer st
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer i, nodsiz, j
    integer stlu, length

--- a/unix/boot/spp/rpp/ratlibr/lookup.r
+++ b/unix/boot/spp/rpp/ratlibr/lookup.r
@@ -7,7 +7,7 @@ include	defs
    integer info (ARB)
    pointer st
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer i, nodsiz, kluge
    integer stlu

--- a/unix/boot/spp/rpp/ratlibr/mktabl.r
+++ b/unix/boot/spp/rpp/ratlibr/mktabl.r
@@ -5,7 +5,7 @@ include	defs
    pointer function mktabl (nodsiz)
    integer nodsiz
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer st
    pointer dsget

--- a/unix/boot/spp/rpp/ratlibr/rmtabl.r
+++ b/unix/boot/spp/rpp/ratlibr/rmtabl.r
@@ -5,7 +5,7 @@ include	defs
    subroutine rmtabl (st)
    pointer st
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer i
 

--- a/unix/boot/spp/rpp/ratlibr/sctabl.r
+++ b/unix/boot/spp/rpp/ratlibr/sctabl.r
@@ -7,7 +7,7 @@ include	defs
    character sym (ARB)
    integer info (ARB)
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    pointer bucket, walker
    pointer dsget

--- a/unix/boot/spp/rpp/ratlibr/stlu.r
+++ b/unix/boot/spp/rpp/ratlibr/stlu.r
@@ -6,7 +6,7 @@ include	defs
    character symbol (ARB)
    pointer node, pred, st
 
-   DS_DECL(Mem, 1)
+   DS_DECL(Mem, MEMSIZE)
 
    integer hash, i, j, nodsiz
 


### PR DESCRIPTION
This fixes a problem that rpp.e does not work correctly when build
with optimization: since cdsmem is initialized everywhere as `integer
mem(1)` the C compiler (after f2c) assumes that the variable is not an
array, but a pointer to a single variable, and any subsequent write
can be replaced by just writing the last value.

It should really be a `integer mem(60000)`.